### PR TITLE
Remove mainland references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 dist
+.DS_Store

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mainland-layer",
+  "name": "newrelic-lambda-layers",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mainland-layer",
+  "name": "newrelic-lambda-layers",
   "version": "0.1.0",
   "description": "New Relic Installer for serverless APM layers.",
   "main": "",
@@ -9,20 +9,20 @@
     "README.md"
   ],
   "scripts": {
-    "build": "npm install && mkdir -p node_modules/newrelic-lambda-wrapper && cp index.js node_modules/newrelic-lambda-wrapper && mkdir -p nodejs && cp -r node_modules nodejs && zip -rq ../dist/nodejs/MainlandLayer.zip nodejs && rm -rf ./nodejs",
-    "clean": "rm ../dist/nodejs/MainlandLayer.zip",
+    "build": "npm install && mkdir -p node_modules/newrelic-lambda-wrapper && cp index.js node_modules/newrelic-lambda-wrapper && mkdir -p nodejs && cp -r node_modules nodejs && zip -rq ../dist/nodejs/NewRelicLayer.zip nodejs && rm -rf ./nodejs",
+    "clean": "rm ../dist/nodejs/NewRelicLayer.zip",
     "lint": "eslint ./*.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iopipe/mainland-layer.git"
+    "url": "git+https://github.com/iopipe/newrelic-lambda-layers.git"
   },
   "author": "IOpipe",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/iopipe/serverless-iopipe-layers/issues"
+    "url": "https://github.com/iopipe/newrelic-lambda-layers/issues"
   },
-  "homepage": "https://github.com/iopipe/serverless-plugin-iopipe-layers#readme",
+  "homepage": "https://github.com/iopipe/newrelic-lambda-layers#readme",
   "dependencies": {
     "@newrelic/aws-sdk": "^0.3.0",
     "newrelic": "^5.13.1"


### PR DESCRIPTION
This cleans up the pre-announcement naming to reduce confusion in the future.